### PR TITLE
Rename deprecated lifecycle methods

### DIFF
--- a/lib/react-reorderable.js
+++ b/lib/react-reorderable.js
@@ -142,7 +142,7 @@ function getNodesOrder(current, sibling, order) {
 }
 
 var ReactReorderable = createReactClass({
-  componentWillMount: function () {
+  UNSAFE_componentWillMount: function () {
     window.addEventListener('mouseup', this._mouseupHandler = function () {
       this.setState({
         mouseDownPosition: null
@@ -152,7 +152,7 @@ var ReactReorderable = createReactClass({
   componentWillUnmount: function () {
     window.removeEventListener('mouseup', this._mouseupHandler);
   },
-  componentWillReceiveProps: function (nextProps) {
+  UNSAFE_componentWillReceiveProps: function (nextProps) {
     if (nextProps.children) {
       var res = indexChildren(nextProps.children);
       this.setState({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-reorderable",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Sortable component for ReactJS",
   "main": "lib/react-reorderable.js",
   "scripts": {


### PR DESCRIPTION
These lifecycle methods will be removed by React 17.

Unable to build is a problem though.